### PR TITLE
fix for issue #4

### DIFF
--- a/internal/pkg/relays/docker/docker.go
+++ b/internal/pkg/relays/docker/docker.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"regexp"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -26,6 +27,9 @@ type image struct {
 	Path string
 	Tags []string
 }
+
+// replace "docker.io/usr/appname:tag" with "usr/apname:tag" when searching locally
+var re = regexp.MustCompile(`^docker.io/`)
 
 //
 func (s *image) ref() string {
@@ -142,6 +146,7 @@ func (dc *dockerClient) listImages(ref string) ([]*image, error) {
 	ret := []*image{}
 
 	if err == nil {
+		ref = re.ReplaceAllString(ref, "")
 		fRepo, fPath, fTag := SplitRef(ref)
 		for _, img := range imgs {
 			var i *image


### PR DESCRIPTION
This fix could possibly be implemented at a higher level of the tool (after reading the config file maybe). I'm currently testing the docker engine relay, so I've implemented a fix for that part of the code.  

The problem was that the docker engine removes **docker.io** from the image name (**docker.io/user/image:tag**). When re-tagging images, client.listImages() fails to match the locally pulled image (**user/image:tag**) with the config file defined image (**docker.io/user/image:tag**).  

The fix removes "docker.io/" when matching the images to be tagged.  