### PR TITLE
refresh mappings based on task intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 scratchpad
 *.sublime*
 .makerc
+.idea

--- a/internal/pkg/sync/sync.go
+++ b/internal/pkg/sync/sync.go
@@ -165,6 +165,10 @@ func (s *Sync) SyncFromConfig(conf *SyncConfig) error {
 //
 func (s *Sync) syncTask(t *Task) {
 
+    if t.MappingFile !=nil{
+        t.refreshMapping()
+    }
+
 	if t.tooSoon() {
 		log.WithField("task", t.Name).Info("task fired too soon, skipping")
 		return


### PR DESCRIPTION
1. An optional field `mappings_file:</path/to/mappings>` can be added to config file wherein the mappings can be listed. 
2. Allows for dynamic refresh of mappings. This means, we can edit the contents of the `mappings_file` to fetch fresh images.
3. Added functions `validateMappings()` and `refreshMappings()` in `task.go`
4. Changed `sync.go` to include call to `refreshMappings()` in function `syncTask()`