### PR TITLE
ecr: implement multiple credential profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,21 @@ tasks:
     #  - 'auth' contains the base64 encoded credentials for the registry
     #    in JSON form {"username": "...", "password": "..."}
     #  - 'auth-refresh' specifies an interval for automatic retrieval of
-    #    credentials; only for AWS ECR (see below)
+    #    credentials; only for AWS ECR (see below). If ommitted, will refresh
+    #    according to the expiration time returned by AWS
     #  - 'skip-tls-verify' determines whether to skip TLS verification for the
     #    registry server (only for 'skopeo', see note below); defaults to false
+    #  - 'auth-config' map of configuration options for registry auth.
+    #    Currently only ECR supports:
+    #    * 'aws-profile' name of AWS credential profile to use for ECR API calls
     source:
       registry: source-registry.acme.com
       auth: eyJ1c2VybmFtZSI6ICJhbGV4IiwgInBhc3N3b3JkIjogInNlY3JldCJ9Cg==
     target:
       registry: dest-registry.acme.com
       auth: eyJ1c2VybmFtZSI6ICJhbGV4IiwgInBhc3N3b3JkIjogImFsc29zZWNyZXQifQo=
+      auth-config:
+        aws-profile: foobar
       skip-tls-verify: true
 
     # 'mappings' is a list of 'from':'to' pairs that define mappings of image

--- a/internal/pkg/auth/credentials.go
+++ b/internal/pkg/auth/credentials.go
@@ -45,6 +45,7 @@ type Credentials struct {
 	token     *Token
 	refresher Refresher
 	auther    Auther
+	config    map[string]string
 }
 
 //
@@ -83,6 +84,15 @@ func (c *Credentials) SetToken(t *Token) {
 //
 func (c *Credentials) SetRefresher(r Refresher) {
 	c.refresher = r
+}
+ 
+//
+func (c *Credentials) Config() *map[string]string {
+	return &c.config
+}
+
+func (c *Credentials) SetConfig(config map[string]string) {
+	c.config = config
 }
 
 //

--- a/internal/pkg/registry/ecr.go
+++ b/internal/pkg/registry/ecr.go
@@ -23,8 +23,9 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	awsecr "github.com/aws/aws-sdk-go/service/ecr"
+
+	"github.com/xelalexv/dregsy/internal/pkg/auth"
 )
 
 //
@@ -47,11 +48,12 @@ func IsECR(registry string) (ecr bool, region, account string) {
 }
 
 //
-func newECR(registry, region, account string) ListSource {
+func newECR(registry, region, account string, creds *auth.Credentials) ListSource {
 	return &ecr{
 		registry: registry,
 		region:   region,
 		account:  account,
+		creds:    creds,
 	}
 }
 
@@ -60,6 +62,7 @@ type ecr struct {
 	registry string
 	region   string
 	account  string
+	creds    *auth.Credentials
 }
 
 //
@@ -104,9 +107,9 @@ func (e *ecr) Ping() error {
 
 //
 func (e *ecr) getService() (*awsecr.ECR, error) {
-	sess, err := session.NewSession()
+	sess, err := auth.NewECRSession(e.region, e.creds.Config())
 	if err != nil {
 		return nil, err
 	}
-	return awsecr.New(sess, &aws.Config{Region: aws.String(e.region)}), nil
+	return awsecr.New(sess), nil
 }

--- a/internal/pkg/registry/repolist.go
+++ b/internal/pkg/registry/repolist.go
@@ -102,7 +102,7 @@ func NewRepoList(registry string, insecure bool, typ ListSourceType,
 			// lib; if the registry is ECR we therefore use a dedicated ECR
 			// lister based on the AWS Go SDK
 			log.Info("using dedicated ECR lister instead of standard catalog")
-			list.source = newECR(registry, region, account)
+			list.source = newECR(registry, region, account, listCreds)
 		} else {
 			list.source = newCatalog(registry, insecure,
 				strings.HasSuffix(server, ".gcr.io"), listCreds)

--- a/internal/pkg/sync/task.go
+++ b/internal/pkg/sync/task.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/xelalexv/dregsy/internal/pkg/auth"
 	"github.com/xelalexv/dregsy/internal/pkg/registry"
 	"github.com/xelalexv/dregsy/internal/pkg/util"
 )
@@ -200,14 +200,12 @@ func (t *Task) ensureTargetExists(ref string) error {
 			return nil
 		}
 
-		sess, err := session.NewSession()
+		sess, err := auth.NewECRSession(region, t.Target.creds.Config())
 		if err != nil {
 			return err
 		}
 
-		svc := ecr.New(sess, &aws.Config{
-			Region: aws.String(region),
-		})
+		svc := ecr.New(sess)
 
 		inpDescr := &ecr.DescribeRepositoriesInput{
 			RegistryId:      aws.String(account),

--- a/test/fixtures/e2e/base/skopeo-ecr-multi-profile.yaml
+++ b/test/fixtures/e2e/base/skopeo-ecr-multi-profile.yaml
@@ -1,0 +1,35 @@
+relay: skopeo
+
+tasks:
+- name: test-ecr-multi-profile-pre
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+    auth: {{ .DockerhubAuth }}
+  target:
+    registry: {{ .ECRRegistry }}
+    auth-refresh: 1h
+    auth-config:
+      aws-profile: dregsy-test-src
+  mappings:
+  - from: library/busybox
+    to: {{ .ECRRepo }}
+    tags: &tags ['1.29.2', '1.29.3', 'latest']
+
+- name: test-ecr-multi-profile
+  interval: 45
+  verbose: true
+  source:
+    registry: {{ .ECRRegistry }}
+    auth-refresh: 1h
+    auth-config:
+      aws-profile: dregsy-test-src
+  target:
+    registry: {{ .ECRRegistry }}
+    auth-refresh: 1h
+    auth-config:
+      aws-profile: dregsy-test-tgt
+  mappings:
+    - from: {{ .ECRRepo }}
+      to: {{ .ECRRepo }}
+      tags: *tags


### PR DESCRIPTION
This makes cross-account syncing much easier, by allowing configuration of two different credential profiles from your AWS SDK configuration.

I updated the README and implemented an E2E test, which generates a credentials file with two profiles, but using the same access keys.

I also ran a real cross-account copy successfully using my branch.

Result of E2E test:

```
$ make ISOLATED=y TEST_OPTS+="-v -run=MultiProfile" tests                                                                                                                                                                                                                              Deleted Images:
untagged: golang@sha256:f6cefbdd25f9a66ec7dcef1ee5deb417882b9db9629a724af8a332fe54e3f7b3
deleted: sha256:272e3f68338f33e2a0bd794e416cb7929de154fcef5d5189566c1c499607bb37
deleted: sha256:eb4d2639c1dcc0d3f9a8575156b59e85a5ab3b9956d5f879b1f4a15e48c7a03a
deleted: sha256:07b990a8e964d8f91336471e0464d5270e6c4b5dc66da7250a5aa013c8e97206
deleted: sha256:2bcd1edc793ec112ae8a710f8c33573e410f4c7f2e0d4440afd0b256cf692226
deleted: sha256:e0746526f645b805c9bb2c895779a9ecef99f425b921e6c0fd6a3a84f8dfa32a
deleted: sha256:c1d02b68d22a9d429b1e5933d12680b2c8be3a513e1476bba6be54b577b419c7
deleted: sha256:883122fdbc326d2ea8477b44b7e82c9d774e0e579e7b6872cbdd067391789006
deleted: sha256:dd5242c2dc8ae9782b73f83281625f45bd6217dc79540e1019d5da0913b491b0

Total reclaimed space: 802.8MB
dregsy-test-registry
74372c9bce97f997a0bb95ea36a51b10efabe0f98c37f6ca3e0ea1427c77dea1

testing using alpine-based image:
=== RUN   TestE2ESkopeoECRMultiProfile
INFO[0000] dregsy                                       
INFO[0001] skopeo version 1.3.1 commit: 1bb50ac33996b2fbf512d82f48d7ca2931bd0eb4 
INFO[0001] relay ready                                   relay=skopeo
INFO[0001] syncing task                                  source=registry.hub.docker.com target=258273616434.dkr.ecr.eu-central-1.amazonaws.com task=test-ecr-multi-profile-pre
INFO[0001] mapping                                       from=/library/busybox to=/dregsy/test
INFO[0001] refreshing credentials                        registry=registry.hub.docker.com
INFO[0001] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0001] target already exists                         ref=258273616434.dkr.ecr.eu-central-1.amazonaws.com/dregsy/test
DEBU[0001] verbatim tags: [1.29.2 1.29.3 latest]        
INFO[0001] syncing tag                                   tag=1.29.2
DEBU[0003] Getting image source signatures              
DEBU[0003] Copying blob sha256:8c5a7da1afbc602695fcb2cd6445743cec5ff32053ea589ea9bd8773b7068185 
DEBU[0004] Copying config sha256:e1ddd7948a1c31709a23cc5b7dfe96e55fc364f90e1cebcde0773a1b5a30dcda 
DEBU[0004] Writing manifest to image destination        
DEBU[0004] Storing signatures                           
INFO[0004] syncing tag                                   tag=1.29.3
DEBU[0006] Getting image source signatures              
DEBU[0007] Copying blob sha256:b4a6e23922ddc3d105fee9afff80151a13fe058143351a8e9294286575f2f37e 
DEBU[0007] Copying config sha256:758ec7f3a1ee85f8f08399b55641bfb13e8c1109287ddc5e22b68c3d653152ee 
DEBU[0007] Writing manifest to image destination        
DEBU[0007] Storing signatures                           
INFO[0007] syncing tag                                   tag=latest
DEBU[0009] Getting image source signatures              
DEBU[0009] Copying blob sha256:8ec32b265e94aafb0d43ab71f1d8f786122c19afb37d25532aea169f414f8881 
DEBU[0010] Copying config sha256:42b97d3c2ae95232263a04324aaf656dc80e7792dee6629a9eff276cdfb806c0 
DEBU[0010] Writing manifest to image destination        
DEBU[0010] Storing signatures                           
DEBU[0010] task starts ticking                           task=test-ecr-multi-profile
DEBU[0010] sending initial fire                          task=test-ecr-multi-profile
INFO[0010] waiting for next sync task...                
INFO[0010] syncing task                                  source=258273616434.dkr.ecr.eu-central-1.amazonaws.com target=258273616434.dkr.ecr.eu-central-1.amazonaws.com task=test-ecr-multi-profile
INFO[0010] mapping                                       from=/dregsy/test to=/dregsy/test
INFO[0010] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0010] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0010] target already exists                         ref=258273616434.dkr.ecr.eu-central-1.amazonaws.com/dregsy/test
DEBU[0010] verbatim tags: [1.29.2 1.29.3 latest]        
INFO[0010] syncing tag                                   tag=1.29.2
DEBU[0011] Getting image source signatures              
DEBU[0011] Copying blob sha256:8c5a7da1afbc602695fcb2cd6445743cec5ff32053ea589ea9bd8773b7068185 
DEBU[0011] Copying config sha256:e1ddd7948a1c31709a23cc5b7dfe96e55fc364f90e1cebcde0773a1b5a30dcda 
DEBU[0012] Writing manifest to image destination        
DEBU[0012] Storing signatures                           
INFO[0012] syncing tag                                   tag=1.29.3
DEBU[0012] Getting image source signatures              
DEBU[0013] Copying blob sha256:b4a6e23922ddc3d105fee9afff80151a13fe058143351a8e9294286575f2f37e 
DEBU[0013] Copying config sha256:758ec7f3a1ee85f8f08399b55641bfb13e8c1109287ddc5e22b68c3d653152ee 
DEBU[0013] Writing manifest to image destination        
DEBU[0013] Storing signatures                           
INFO[0013] syncing tag                                   tag=latest
DEBU[0014] Getting image source signatures              
DEBU[0014] Copying blob sha256:8ec32b265e94aafb0d43ab71f1d8f786122c19afb37d25532aea169f414f8881 
DEBU[0014] Copying config sha256:42b97d3c2ae95232263a04324aaf656dc80e7792dee6629a9eff276cdfb806c0 
DEBU[0014] Writing manifest to image destination        
DEBU[0015] Storing signatures                           
INFO[0015] waiting for next sync task...                
INFO[0015] TEST - shutting down dregsy                  
INFO[0015] shutdown flagged, stopping ...               
DEBU[0015] stopping tasks                               
DEBU[0015] task exited                                   task=test-ecr-multi-profile-pre
DEBU[0015] task exiting                                  task=test-ecr-multi-profile
DEBU[0015] task exited                                   task=test-ecr-multi-profile
INFO[0015] all done                                     
DEBU[0015] exit main                                    
INFO[0015] TEST - dregsy stopped                        
INFO[0015] TEST - validating result                     
INFO[0015] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0015] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
--- PASS: TestE2ESkopeoECRMultiProfile (15.89s)
PASS
coverage: 33.6% of statements in ./...
ok  	github.com/xelalexv/dregsy/cmd/dregsy	15.894s	coverage: 33.6% of statements in ./...
?   	github.com/xelalexv/dregsy/internal/pkg/auth	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/registry	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/relays/docker	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/relays/skopeo	[no test files]
testing: warning: no tests to run
PASS
coverage: 1.0% of statements in ./...
ok  	github.com/xelalexv/dregsy/internal/pkg/sync	0.008s	coverage: 1.0% of statements in ./... [no tests to run]
?   	github.com/xelalexv/dregsy/internal/pkg/tags	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/test	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/test/registries	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/util	[no test files]

coverage report is in _build/coverage-alpine.html

Total reclaimed space: 0B
dregsy-test-registry
1eb20fe21825252e7118198f8d8445d58a2325ed37292624eca784c7af5d0b2d

testing using ubuntu-based image:
=== RUN   TestE2ESkopeoECRMultiProfile
INFO[0000] dregsy                                       
INFO[0001] skopeo version 1.3.0                         
INFO[0001] relay ready                                   relay=skopeo
INFO[0001] syncing task                                  source=registry.hub.docker.com target=258273616434.dkr.ecr.eu-central-1.amazonaws.com task=test-ecr-multi-profile-pre
INFO[0001] mapping                                       from=/library/busybox to=/dregsy/test
INFO[0001] refreshing credentials                        registry=registry.hub.docker.com
INFO[0001] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0001] target already exists                         ref=258273616434.dkr.ecr.eu-central-1.amazonaws.com/dregsy/test
DEBU[0001] verbatim tags: [1.29.2 1.29.3 latest]        
INFO[0001] syncing tag                                   tag=1.29.2
DEBU[0002] Getting image source signatures              
DEBU[0003] Copying blob sha256:8c5a7da1afbc602695fcb2cd6445743cec5ff32053ea589ea9bd8773b7068185 
DEBU[0003] Copying config sha256:e1ddd7948a1c31709a23cc5b7dfe96e55fc364f90e1cebcde0773a1b5a30dcda 
DEBU[0004] Writing manifest to image destination        
DEBU[0004] Storing signatures                           
INFO[0004] syncing tag                                   tag=1.29.3
DEBU[0006] Getting image source signatures              
DEBU[0006] Copying blob sha256:b4a6e23922ddc3d105fee9afff80151a13fe058143351a8e9294286575f2f37e 
DEBU[0006] Copying config sha256:758ec7f3a1ee85f8f08399b55641bfb13e8c1109287ddc5e22b68c3d653152ee 
DEBU[0007] Writing manifest to image destination        
DEBU[0007] Storing signatures                           
INFO[0007] syncing tag                                   tag=latest
DEBU[0009] Getting image source signatures              
DEBU[0009] Copying blob sha256:8ec32b265e94aafb0d43ab71f1d8f786122c19afb37d25532aea169f414f8881 
DEBU[0009] Copying config sha256:42b97d3c2ae95232263a04324aaf656dc80e7792dee6629a9eff276cdfb806c0 
DEBU[0010] Writing manifest to image destination        
DEBU[0010] Storing signatures                           
DEBU[0010] task starts ticking                           task=test-ecr-multi-profile
DEBU[0010] sending initial fire                          task=test-ecr-multi-profile
INFO[0010] waiting for next sync task...                
INFO[0010] syncing task                                  source=258273616434.dkr.ecr.eu-central-1.amazonaws.com target=258273616434.dkr.ecr.eu-central-1.amazonaws.com task=test-ecr-multi-profile
INFO[0010] mapping                                       from=/dregsy/test to=/dregsy/test
INFO[0010] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0010] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0010] target already exists                         ref=258273616434.dkr.ecr.eu-central-1.amazonaws.com/dregsy/test
DEBU[0010] verbatim tags: [1.29.2 1.29.3 latest]        
INFO[0010] syncing tag                                   tag=1.29.2
DEBU[0010] Getting image source signatures              
DEBU[0011] Copying blob sha256:8c5a7da1afbc602695fcb2cd6445743cec5ff32053ea589ea9bd8773b7068185 
DEBU[0011] Copying config sha256:e1ddd7948a1c31709a23cc5b7dfe96e55fc364f90e1cebcde0773a1b5a30dcda 
DEBU[0011] Writing manifest to image destination        
DEBU[0011] Storing signatures                           
INFO[0011] syncing tag                                   tag=1.29.3
DEBU[0012] Getting image source signatures              
DEBU[0012] Copying blob sha256:b4a6e23922ddc3d105fee9afff80151a13fe058143351a8e9294286575f2f37e 
DEBU[0012] Copying config sha256:758ec7f3a1ee85f8f08399b55641bfb13e8c1109287ddc5e22b68c3d653152ee 
DEBU[0012] Writing manifest to image destination        
DEBU[0013] Storing signatures                           
INFO[0013] syncing tag                                   tag=latest
DEBU[0013] Getting image source signatures              
DEBU[0013] Copying blob sha256:8ec32b265e94aafb0d43ab71f1d8f786122c19afb37d25532aea169f414f8881 
DEBU[0014] Copying config sha256:42b97d3c2ae95232263a04324aaf656dc80e7792dee6629a9eff276cdfb806c0 
DEBU[0014] Writing manifest to image destination        
DEBU[0014] Storing signatures                           
INFO[0014] waiting for next sync task...                
INFO[0014] TEST - shutting down dregsy                  
INFO[0014] shutdown flagged, stopping ...               
DEBU[0014] stopping tasks                               
DEBU[0014] task exited                                   task=test-ecr-multi-profile-pre
DEBU[0014] task exiting                                  task=test-ecr-multi-profile
DEBU[0014] task exited                                   task=test-ecr-multi-profile
INFO[0014] all done                                     
DEBU[0014] exit main                                    
INFO[0015] TEST - dregsy stopped                        
INFO[0015] TEST - validating result                     
INFO[0015] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
INFO[0015] refreshing credentials                        registry=258273616434.dkr.ecr.eu-central-1.amazonaws.com
--- PASS: TestE2ESkopeoECRMultiProfile (16.31s)
PASS
coverage: 33.6% of statements in ./...
ok  	github.com/xelalexv/dregsy/cmd/dregsy	16.319s	coverage: 33.6% of statements in ./...
?   	github.com/xelalexv/dregsy/internal/pkg/auth	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/registry	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/relays/docker	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/relays/skopeo	[no test files]
testing: warning: no tests to run
PASS
coverage: 1.0% of statements in ./...
ok  	github.com/xelalexv/dregsy/internal/pkg/sync	0.009s	coverage: 1.0% of statements in ./... [no tests to run]
?   	github.com/xelalexv/dregsy/internal/pkg/tags	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/test	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/test/registries	[no test files]
?   	github.com/xelalexv/dregsy/internal/pkg/util	[no test files]

coverage report is in _build/coverage-ubuntu.html
```