### PR TITLE
Allow skopeo to sync all architectures

### DIFF
--- a/internal/pkg/relays/skopeo/skopeorelay.go
+++ b/internal/pkg/relays/skopeo/skopeorelay.go
@@ -86,6 +86,7 @@ func (r *SkopeoRelay) Sync(srcRef, srcAuth string, srcSkipTLSVerify bool,
 
 	cmd := []string{
 		"--insecure-policy",
+		"--all"
 		"copy",
 	}
 

--- a/internal/pkg/relays/skopeo/skopeorelay.go
+++ b/internal/pkg/relays/skopeo/skopeorelay.go
@@ -86,7 +86,7 @@ func (r *SkopeoRelay) Sync(srcRef, srcAuth string, srcSkipTLSVerify bool,
 
 	cmd := []string{
 		"--insecure-policy",
-		"--all"
+		"--all",
 		"copy",
 	}
 


### PR DESCRIPTION
Currently, if there are images with different architectures under the same tag, only the default architecture will be synced. 

This extra command line option [--all](https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md) allows skopeo to sync all the architectures.

**PLEASE NOTE:** I am not at all familiar with go, the suggested change "should work". I also was not able to get build run locally, so I have no idea if this works. I would gladly appreciate if this would end up in a release. Wish I could do more to help, but I can only ask for at this point.