### PR TITLE
Add a dry-run option to dregsy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 scratchpad
 *.sublime*
 .makerc
+.vscode/**

--- a/cmd/dregsy/main.go
+++ b/cmd/dregsy/main.go
@@ -81,6 +81,7 @@ func main() {
 
 	fs := flag.NewFlagSet("dregsy", flag.ContinueOnError)
 	configFile := fs.String("config", "", "path to config file")
+	dryRun := fs.Bool("dry-run", false, "perform a validation of the execution")
 
 	if testRound {
 		if len(testArgs) > 0 {
@@ -94,8 +95,11 @@ func main() {
 
 	if len(*configFile) == 0 {
 		version()
-		fmt.Println("synopsis: dregsy -config={config file}")
+		fmt.Println("synopsis: dregsy -config={config file} [--dry-run]")
 		exit(1)
+	}
+	if *dryRun {
+		fmt.Println("It's going to be a dry run, no real sync will happen")
 	}
 
 	version()
@@ -103,7 +107,7 @@ func main() {
 	conf, err := sync.LoadConfig(*configFile)
 	failOnError(err)
 
-	s, err := sync.New(conf)
+	s, err := sync.New(conf, *dryRun)
 	failOnError(err)
 
 	if testRound {

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
 	google.golang.org/grpc v1.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,9 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/pkg/sync/sync.go
+++ b/internal/pkg/sync/sync.go
@@ -226,8 +226,9 @@ func (s *Sync) syncTask(t *Task) {
 
 			if s.dryRun {
 				log.WithFields(log.Fields{
-					"task":   t.Name,
-					"tags": tags}).Info("list of tags")
+					"image name": t.Name,
+					"list of tags": tags,
+					"number of images": len(tags)}).Info("list of tags")
 				continue
 			}
 


### PR DESCRIPTION
This code is adding a new optional parameter `--dry-run` to dregsy's command line. 
It allows _easier_ debugging of matching tags based on the specified configuration without syncing all the information to the target docker registry.

- faster
- simple
- cheaper