### PR TITLE
forcing HTTP scheme for insecure registry

### DIFF
--- a/internal/pkg/registry/catalog.go
+++ b/internal/pkg/registry/catalog.go
@@ -61,8 +61,12 @@ type catalog struct {
 
 //
 func (c *catalog) Retrieve(maxItems int) ([]string, error) {
+	var regopts []gocrname.Option
+	if c.insecure {
+		regopts = []gocrname.Option{gocrname.Insecure}
+	}
 
-	reg, err := gocrname.NewRegistry(c.registry)
+	reg, err := gocrname.NewRegistry(c.registry, regopts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid registry: %v", err)
 	}


### PR DESCRIPTION
Even when configuration contains `skip-tls-verify: true` if the registry has a prefix different than `localhost` the Registry.Scheme is always https, and the catalog retrieval fails.