### PR TITLE
Adding support for copying container images with image digest [skopeo only]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## post-`0.4.5` after merging support for pulling with image digests wit skopeo
+- For Skopeo relay, adding support for pulling container images based on the image digest. An image digest looks like this: `sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd`.
+  Below is the behavior of the `skopeo copy` Sync with support for both
+  digests and tags.
+  Warning: Skopeo Docker references with both a tag and a digest are
+  currently not supported.
+
+  The `digests` list & `tags` list are stored in a `mapping` struct.
+  As example, look at the file
+  `test/fixtures/config/skopeo-digest-only-valid.yaml`
+
+  | `digests` list | `tags` list | `dregsy` behavior                             | diff with 0.4.4 |
+  |----------------|-------------|-----------------------------------------------|-----------------|
+  | empty          | empty       | pulls all tags                                | same            |
+  | empty          | NOT empty   | pulls filtered tags only                      | same            |
+  | NOT empty      | NOT empty   | pulls filtered tags AND pulls correct digests | different       |
+  | NOT empty      | empty       | pulls correct digests only, ignores tags      | different       |
+
+  A "correct digest" is a correctly formated AND an existing digest.
+  Skopeo is used to verify if the digest exists before trying to copy it.
+- Adding a simple bash script that uses `openssl` and `podman` to instantiate a simple registryv2 service with an HTTPS endpoint: `test/bin/create_local_registry_https.sh`, for testing purpose.
+- Adding `dregsy` configuration samples, for testing purpose:
+    + `skopeo-digest-bad-formated.yaml`: a config sample with image digests that are badly formated. Dregsy should raise an error in logs and skip to next tag or digest.
+    + `skopeo-digest-dont-exist.yaml`: a config sample with image digests that are formated correctly, but that does not exist. Dregsy should raise an error in logs and skip to next tag or digest.
+    + `skopeo-digest-duplicates.yaml`: a config sample with duplicates image digests. Dregsy should eliminate duplicates and only copy once.
+    + `skopeo-digest-only-valid.yaml`: a config sample with valid image digests that exist on docker hub (`docker.io`). Dregsy should copy them without issue.
+- Adding 2 `podman` or `docker` Containerfiles for x86 and ARM64 architecture: `Containerfile.aarch64-arm64` and `Containerfile.x86_64-amd64`. For testing purpose and local build.
+- Adding a section in the README: _### Building only the `dregsy` binary with `podman`_
+- upgrades:
+    + *Go* 1.20.2 in `Containerfile.aarch64-arm64`, `Containerfile.x86_64-amd64`.
+
+
 ## `0.4.5`
 - upgrades:
     + *Go* 1.20.1

--- a/internal/pkg/digests/digestlist.go
+++ b/internal/pkg/digests/digestlist.go
@@ -1,0 +1,101 @@
+/*
+	Copyright 2023
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	  http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+/*
+	How to get an image digest with skopeo inspect:
+		$ skopeo inspect --format "{{.Digest}}" docker://docker.io/alpine:3.17.1
+		sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+
+	/!\ Skopeo does not support using tags and digest at the same time.
+	This is valid (tag only):
+		$ skopeo inspect --format "{{.Digest}}" docker://docker.io/alpine:3.17.1
+		sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+
+	This is valid (digest only):
+		$ skopeo inspect --format "{{.Digest}}" docker://docker.io/alpine@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+		sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+
+	This is not valid (tag and digest):
+		$ skopeo inspect --format "{{.Digest}}" docker://docker.io/alpine:3.17.1@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+		FATA[0000] Error parsing image name "docker://docker.io/alpine:3.17.1@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a": Docker references with both a tag and digest are currently not supported
+
+*/
+
+package digests
+
+import (
+	"errors"
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// An image digest has the following structure
+// sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+type DigestList struct {
+	Digests []string
+}
+
+func NewDigestList(digests []string) (*DigestList, error) {
+	ret := &DigestList{}
+	if err := ret.addDigests(digests); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// Adds one digest to the list of digests
+func (ds *DigestList) addOneDigest(dig string) error {
+	if isDigest(dig) {
+		log.Debugf("adding digest: %v", dig)
+		ds.Digests = append(ds.Digests, dig)
+		return nil
+	} else {
+		err := errors.New("Error adding digest: bad format - only lowercase is supported")
+		log.Debugf("wrong digest format: %v", dig)
+		return err
+	}
+}
+
+// Add a list of digests (string array)
+func (ds *DigestList) addDigests(digests []string) error {
+	for _, dig := range digests {
+		if err := ds.addOneDigest(dig); err != nil {
+			// this means this digest is not well formated
+			log.Errorf("error bad formated digest: %s", dig)
+			//return err
+		}
+	}
+	return nil
+}
+
+// Return true if list of digest is empty.
+func (ds *DigestList) IsEmpty() bool {
+	if ds.Digests == nil {
+		return true
+	} else {
+		return false
+	}
+}
+
+// This function verifies if the image digest string is properly formated.
+// An image digest has the following structure:
+// sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+// Does not accept UPPERCASE in the digest, only lowercase.
+func isDigest(digest string) bool {
+	var re = regexp.MustCompile(`(?m)^sha256:[a-f0-9]{64}$`)
+	return re.MatchString(digest)
+}

--- a/internal/pkg/relays/types.go
+++ b/internal/pkg/relays/types.go
@@ -14,13 +14,18 @@
 	limitations under the License.
 */
 
+/*
+	An image digest is formated like this:
+	sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
+*/
+
 package relays
 
 import (
+	"github.com/xelalexv/dregsy/internal/pkg/digests"
 	"github.com/xelalexv/dregsy/internal/pkg/tags"
 )
 
-//
 type SyncOptions struct {
 	//
 	SrcRef           string
@@ -30,13 +35,16 @@ type SyncOptions struct {
 	TrgtRef           string
 	TrgtAuth          string
 	TrgtSkipTLSVerify bool
-	//
-	Tags     *tags.TagSet
-	Platform string
-	Verbose  bool
+	// Skopeo Docker references with both a tag and digest are currently not supported
+	Tags    *tags.TagSet
+	Digests *digests.DigestList
+	// skopeo copy --preserve-digests option
+	// TODO change location of PreserveDigests ? see internal/pkg/sync/task.go
+	PreserveDigests bool
+	Platform        string
+	Verbose         bool
 }
 
-//
 type Support interface {
 	Platform(p string) error
 }

--- a/internal/pkg/sync/sync.go
+++ b/internal/pkg/sync/sync.go
@@ -31,21 +31,18 @@ import (
 	"github.com/xelalexv/dregsy/internal/pkg/util"
 )
 
-//
 type Relay interface {
 	Prepare() error
 	Dispose() error
 	Sync(opt *relays.SyncOptions) error
 }
 
-//
 type Sync struct {
 	relay    Relay
 	shutdown chan bool
 	ticks    chan bool
 }
 
-//
 func New(conf *SyncConfig) (*Sync, error) {
 
 	sync := &Sync{}
@@ -82,13 +79,11 @@ func New(conf *SyncConfig) (*Sync, error) {
 	return sync, nil
 }
 
-//
 func (s *Sync) Shutdown() {
 	s.shutdown <- true
 	s.WaitForTick()
 }
 
-//
 func (s *Sync) tick() {
 	select {
 	case s.ticks <- true:
@@ -96,17 +91,14 @@ func (s *Sync) tick() {
 	}
 }
 
-//
 func (s *Sync) WaitForTick() {
 	<-s.ticks
 }
 
-//
 func (s *Sync) Dispose() {
 	s.relay.Dispose()
 }
 
-//
 func (s *Sync) SyncFromConfig(conf *SyncConfig, taskFilter string) error {
 
 	if taskFilter == "" {
@@ -175,7 +167,6 @@ func (s *Sync) SyncFromConfig(conf *SyncConfig, taskFilter string) error {
 	return nil
 }
 
-//
 func (s *Sync) syncTask(t *Task) {
 
 	if t.tooSoon() {
@@ -222,6 +213,7 @@ func (s *Sync) syncTask(t *Task) {
 				break
 			}
 
+			// add digests support
 			if err := s.relay.Sync(&relays.SyncOptions{
 				SrcRef:            src,
 				SrcAuth:           t.Source.GetAuth(),
@@ -231,6 +223,8 @@ func (s *Sync) syncTask(t *Task) {
 				TrgtSkipTLSVerify: t.Target.SkipTLSVerify,
 				Tags:              m.tagSet,
 				Platform:          m.Platform,
+				Digests:           m.digestList,
+				PreserveDigests:   m.PreserveDigests,
 				Verbose:           t.Verbose}); err != nil {
 				log.Error(err)
 				t.fail(true)

--- a/test/fixtures/config/skopeo-digest-bad-formated.yaml
+++ b/test/fixtures/config/skopeo-digest-bad-formated.yaml
@@ -1,0 +1,97 @@
+# This file is for testing the behaviour of dregsy when the image digests are
+# not correctly formated. Dregsy ignores bad formated image digests.
+# Correct image digest format is: 
+# sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+relay: skopeo
+
+lister:
+  maxItems: 50
+  cacheDuration: 30m
+
+tasks:
+- name: test-skopeo-digest-bad-formated-no-sha256-prefix
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  # Using either the WEB GUI at https://hub.docker.com/_/busybox/tags. Or using
+  # the tool crane* to get digests from CLI.
+  # *crane : https://github.com/google/go-containerregistry/tree/main/cmd/crane
+  #
+  # $ crane digest --platform="linux/amd64" library/busybox:1.29.2
+  # sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+  #
+  # $ crane digest --platform="linux/arm/v6" library/busybox:1.29.2
+  # sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+  #
+  # $ crane digest --platform="linux/arm64" library/busybox:1.29.3
+  # sha256:76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470
+  - from: library/busybox
+    digests:
+    - 5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+    to: skopeo/library/busybox
+
+- name: test-skopeo-digest-bad-formated-at
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  - from: library/busybox
+    digests:
+    - sha256@76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470
+    to: skopeo/library/busybox
+
+- name: test-skopeo-digest-bad-formated-no-colon
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  - from: library/busybox
+    digests:
+    - sha2566ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+    to: skopeo/library/busybox
+
+- name: test-skopeo-digest-bad-formated-truncated1
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  - from: library/busybox
+    digests:
+    - sha256:76582bc9c592
+    to: skopeo/library/busybox
+
+- name: test-skopeo-digest-bad-formated-truncated2
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  - from: library/busybox
+    digests:
+    - 76582bc9c592
+    to: skopeo/library/busybox

--- a/test/fixtures/config/skopeo-digest-dont-exist.yaml
+++ b/test/fixtures/config/skopeo-digest-dont-exist.yaml
@@ -1,0 +1,34 @@
+relay: skopeo
+
+lister:
+  maxItems: 50
+  cacheDuration: 30m
+
+tasks:
+- name: test-skopeo-digest-dont-exist
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  # Using either the WEB GUI at https://hub.docker.com/_/busybox/tags. Or using
+  # the tool crane* to get digests from CLI.
+  # *crane : https://github.com/google/go-containerregistry/tree/main/cmd/crane
+  #
+  # $ crane digest --platform="linux/amd64" library/busybox@sha256:94dc472baeef08c56d37851614f7c2c02cf83fa449a355c193747ffd7e80f4ed
+  # Error: GET https://index.docker.io/v2/library/busybox/manifests/sha256:94dc472baeef08c56d37851614f7c2c02cf83fa449a355c193747ffd7e80f4ed: MANIFEST_UNKNOWN: manifest unknown; unknown manifest name=library/busybox revision=sha256:94dc472baeef08c56d37851614f7c2c02cf83fa449a355c193747ffd7e80f4ed
+  - from: library/busybox
+    to: skopeo/library/busybox
+    digests:
+    # below exists
+    - sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+    # below exists
+    - sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+    # below does not exist
+    - sha256:94dc472baeef08c56d37851614f7c2c02cf83fa449a355c193747ffd7e80f4ed
+    # below exists
+    - sha256:76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470

--- a/test/fixtures/config/skopeo-digest-duplicates.yaml
+++ b/test/fixtures/config/skopeo-digest-duplicates.yaml
@@ -1,0 +1,36 @@
+relay: skopeo
+
+lister:
+  maxItems: 50
+  cacheDuration: 30m
+
+tasks:
+- name: test-skopeo-digest-duplicate
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  # Using either the WEB GUI at https://hub.docker.com/_/busybox/tags. Or using
+  # the tool crane* to get digests from CLI.
+  # *crane : https://github.com/google/go-containerregistry/tree/main/cmd/crane
+  #
+  # $ crane digest --platform="linux/amd64" library/busybox:1.29.2
+  # sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+  #
+  # $ crane digest --platform="linux/arm/v6" library/busybox:1.29.2
+  # sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+  #
+  # $ crane digest --platform="linux/arm64" library/busybox:1.29.3
+  # sha256:76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470
+  - from: library/busybox
+    digests:
+    - sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+    - sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+    - sha256:76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470
+    - sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+    to: skopeo/library/busybox

--- a/test/fixtures/config/skopeo-digest-only-valid.yaml
+++ b/test/fixtures/config/skopeo-digest-only-valid.yaml
@@ -1,0 +1,39 @@
+# This file is for testing the behaviour of dregsy when the image digests are
+# valid image digests.
+# test/fixtures/config/skopeo-only-valid-digests.yaml
+relay: skopeo
+
+lister:
+  maxItems: 50
+  cacheDuration: 30m
+
+tasks:
+- name: test-skopeo-only-valid-digests
+  interval: 30
+  verbose: true
+  source:
+    registry: registry.hub.docker.com
+  target:
+    registry: 127.0.0.1:5000
+    #auth: <your_token_here>
+    skip-tls-verify: true
+  mappings:
+  # Using either the WEB GUI at https://hub.docker.com/_/busybox/tags. Or using
+  # the tool crane* to get digests from CLI.
+  # *crane : https://github.com/google/go-containerregistry/tree/main/cmd/crane
+  #
+  # $ crane digest --platform="linux/amd64" library/busybox:1.29.2
+  # sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+  #
+  # $ crane digest --platform="linux/arm/v6" library/busybox:1.29.2
+  # sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+  #
+  # $ crane digest --platform="linux/arm64" library/busybox:1.29.3
+  # sha256:76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470
+  - from: library/busybox
+    to: skopeo/library/busybox
+    digests:
+    - sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd
+    - sha256:76582bc9c59276ea11459bf5ff4f54fd5b7fd23ff622d80479156108fdd26470
+    - sha256:6ba3c395f0a2941114d8dcdf80bedcc7e654252f5870dd94daff9cc3188f3eb2
+    preserve-digests: true


### PR DESCRIPTION
Adding support for copying container images with image digest [skopeo only].

## Related issue

https://github.com/xelalexv/dregsy/issues/86

## TODOs

I started implementing some tests, but tests needs to be improved.

## Feature details

- For Skopeo relay, adding support for pulling container images based on the image digest. An image digest looks like this: `sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd`.
  Below is the behavior of the `skopeo copy` Sync with support for both
  digests and tags.
  Warning: Skopeo Docker references with both a tag and a digest are
  currently not supported.

  The `digests` list & `tags` list are stored in a `mapping` struct.
  As example, look at the file
  `test/fixtures/config/skopeo-digest-only-valid.yaml`

  | `digests` list | `tags` list | `dregsy` behavior                             | diff with 0.4.4 |
  |----------------|-------------|-----------------------------------------------|-----------------|
  | empty          | empty       | pulls all tags                                | same            |
  | empty          | NOT empty   | pulls filtered tags only                      | same            |
  | NOT empty      | NOT empty   | pulls filtered tags AND pulls correct digests | different       |
  | NOT empty      | empty       | pulls correct digests only, ignores tags      | different       |

  A "correct digest" is a correctly formated AND an existing digest.
  Skopeo is used to verify if the digest exists before trying to copy it.
- Adding a simple bash script that uses `openssl` and `podman` to instantiate a simple registryv2 service with an HTTPS endpoint: `test/bin/create_local_registry_https.sh`, for testing purpose.
- Adding `dregsy` configuration samples, for testing purpose:
    + `skopeo-digest-bad-formated.yaml`: a config sample with image digests that are badly formated. Dregsy should raise an error in logs and skip to next tag or digest.
    + `skopeo-digest-dont-exist.yaml`: a config sample with image digests that are formated correctly, but that does not exist. Dregsy should raise an error in logs and skip to next tag or digest.
    + `skopeo-digest-duplicates.yaml`: a config sample with duplicates image digests. Dregsy should eliminate duplicates and only copy once.
    + `skopeo-digest-only-valid.yaml`: a config sample with valid image digests that exist on docker hub (`docker.io`). Dregsy should copy them without issue.
- Adding 2 `podman` or `docker` Containerfiles for x86 and ARM64 architecture: `Containerfile.aarch64-arm64` and `Containerfile.x86_64-amd64`. For testing purpose and local build.
- Adding a section in the README: _### Building only the `dregsy` binary with `podman`_
- upgrades:
    + *Go* 1.20.2 in `Containerfile.aarch64-arm64`, `Containerfile.x86_64-amd64`.
