### PR TITLE
fix: logic when to set gcr refresher

### DIFF
--- a/internal/pkg/sync/location.go
+++ b/internal/pkg/sync/location.go
@@ -124,7 +124,7 @@ func (l *Location) validate() error {
 	// If the credentials were provided we're assuming the user wants to use
 	// them and not configure the refresher, otherwise (unless auth is disabled)
 	// we'll use the GCR refresher.
-	if l.IsGCR() && (!disableAuth || l.creds.Empty()) {
+	if l.IsGCR() && !disableAuth && l.creds.Empty() {
 		l.creds.SetRefresher(auth.NewGCRAuthRefresher())
 	}
 


### PR DESCRIPTION
FIX:
it needs to be AND operator to  check if not disabled auth and creds are empty, otherwise its not working for public gcr repos with auth set to none as its falls down to set refresher logic which is not intended logic or if correct auth is provided it will still falls down to set refresher logic in case of using short living oidc token.


Change made in this PR https://github.com/xelalexv/dregsy/pull/92 broke logic for at least using public repos without auth.
In case if auth is set to none, then the existing logic sets creds to nill https://github.com/xelalexv/dregsy/blob/6eb8c839f6a2e04c3d31df2ffee16177d7fc1ddd/internal/pkg/sync/location.go#L90
which then later https://github.com/xelalexv/dregsy/blob/6eb8c839f6a2e04c3d31df2ffee16177d7fc1ddd/internal/pkg/sync/location.go#L127 makes conditions always true, because if auth is none then creds will be nill therefore empty or if auth provided still will be set refresher.


With using AND operator if correct auth is set, it wont set refresher but rather use provided auth to authenticate, or if auth is set to empty string or some wrong base64 encoded json creds will be empty and it will then try to read env vars or instance profile to authenticate.