### PR TITLE
fix: only check for gcr.io as a suffix to include gcr.io aswell as eu.gcr.io etc

### DIFF
--- a/internal/pkg/registry/index.go
+++ b/internal/pkg/registry/index.go
@@ -102,3 +102,8 @@ func isDockerHub(reg string) bool {
 		strings.HasSuffix(reg, ".docker.com") ||
 		strings.HasSuffix(reg, ".docker.io")
 }
+
+//
+func IsGCR(reg string) bool {
+	return reg == "gcr.io" || strings.HasSuffix(reg, ".gcr.io")
+}

--- a/internal/pkg/registry/repolist.go
+++ b/internal/pkg/registry/repolist.go
@@ -108,8 +108,7 @@ func NewRepoList(registry string, insecure bool, typ ListSourceType,
 				list.source = newECR(registry, region, account)
 			}
 		} else {
-			list.source = newCatalog(registry, insecure,
-				strings.HasSuffix(server, "gcr.io"), listCreds)
+			list.source = newCatalog(registry, insecure, IsGCR(server), listCreds)
 		}
 
 	default:

--- a/internal/pkg/registry/repolist.go
+++ b/internal/pkg/registry/repolist.go
@@ -109,7 +109,7 @@ func NewRepoList(registry string, insecure bool, typ ListSourceType,
 			}
 		} else {
 			list.source = newCatalog(registry, insecure,
-				strings.HasSuffix(server, ".gcr.io"), listCreds)
+				strings.HasSuffix(server, "gcr.io"), listCreds)
 		}
 
 	default:

--- a/internal/pkg/sync/location.go
+++ b/internal/pkg/sync/location.go
@@ -161,6 +161,6 @@ func (l *Location) GetECR() (bool, bool, string, string) {
 
 //
 func (l *Location) IsGCR() bool {
-	return strings.HasSuffix(l.Registry, ".gcr.io") ||
+	return strings.HasSuffix(l.Registry, "gcr.io") ||
 		strings.HasSuffix(l.Registry, "-docker.pkg.dev")
 }

--- a/internal/pkg/sync/location.go
+++ b/internal/pkg/sync/location.go
@@ -124,7 +124,7 @@ func (l *Location) validate() error {
 	// If the credentials were provided we're assuming the user wants to use
 	// them and not configure the refresher, otherwise (unless auth is disabled)
 	// we'll use the GCR refresher.
-	if l.IsGCR() && (!disableAuth || l.creds.Empty()) {
+	if l.IsGCP() && (!disableAuth || l.creds.Empty()) {
 		l.creds.SetRefresher(auth.NewGCRAuthRefresher())
 	}
 
@@ -159,8 +159,7 @@ func (l *Location) GetECR() (bool, bool, string, string) {
 	return l.ecr, l.public, l.region, l.account
 }
 
-//
-func (l *Location) IsGCR() bool {
-	return strings.HasSuffix(l.Registry, "gcr.io") ||
+func (l *Location) IsGCP() bool {
+	return registry.IsGCR(l.Registry) ||
 		strings.HasSuffix(l.Registry, "-docker.pkg.dev")
 }


### PR DESCRIPTION
This was a really small trivial change so I just went for it. Let me know if you want anything changed

seems that dregsy isn't working properly with the "gcr.io" without a region prefix due to checking the suffix ".gcr.io"

I considered checking `l.Registry == "gcr.io"` but this change seemed smaller and should work